### PR TITLE
generate sass files

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -144,14 +144,9 @@ module.exports = generators.Base.extend({
     createStyles: function () {
       const name = this.name,
         folder = this.folder,
-        styles = [
-          'all.css',
-          'print.css'
-        ];
+        styles = 'styles.scss';
 
-      _.each(styles, function (style) {
-        this.fs.copyTpl(this.templatePath(style), path.join(folder, style), { name: name });
-      }.bind(this));
+      this.fs.copyTpl(this.templatePath(styles), path.join(folder, styles), { name: name });
     },
 
     createTemplate: function () {

--- a/app/templates/all.css
+++ b/app/templates/all.css
@@ -1,3 +1,0 @@
-.<%= name %> {
-  /* add your styles here! */
-}

--- a/app/templates/print.css
+++ b/app/templates/print.css
@@ -1,7 +1,0 @@
-.<%= name %> {
-  /*
-    components are hidden by default when printing
-    to add print styles, remove the rule below
-  */
-  display: none;
-}

--- a/app/templates/styles.scss
+++ b/app/templates/styles.scss
@@ -1,0 +1,9 @@
+.<%= name %> {
+  // add your styles here!
+
+  @media print {
+    // components are hidden by default when printing
+    // to add print styles, remove the rule below
+    display: none;
+  }
+}

--- a/app/test.js
+++ b/app/test.js
@@ -7,8 +7,7 @@ const path = require('path'),
   assert = require('yeoman-assert'),
   folder = path.join('components', 'foo'),
   tpl = 'template.nunjucks',
-  all = 'all.css',
-  print = 'print.css',
+  styles = 'styles.scss',
   schema = 'schema.yml',
   bootstrap = 'bootstrap.yml';
 
@@ -35,18 +34,18 @@ describe('clay-component', function () {
       assert.file(folder);
     });
 
-    it('adds all.css', function () {
-      const file = path.join(folder, all);
+    it('adds styles.scss', function () {
+      const file = path.join(folder, styles);
 
       assert.file(file);
       assert.fileContent(file, '.foo {');
     });
 
-    it('adds print.css', function () {
-      const file = path.join(folder, print);
+    it('adds print styles', function () {
+      const file = path.join(folder, styles);
 
       assert.file(file);
-      assert.fileContent(file, '.foo {');
+      assert.fileContent(file, '@media print {');
     });
 
     it('adds template.nunjucks', function () {


### PR DESCRIPTION
The Clay component generator will now generate a single SASS file, rather than generating css files for [responsive filenames](https://github.com/nymag/responsive-filenames). This is an interim step as we move all of our Clay opinions towards PostCSS.
